### PR TITLE
fix(app): totalMemory not being passed to Viz.js options parameter

### DIFF
--- a/src/modules/transformer/src/engines/dot/dot.ts
+++ b/src/modules/transformer/src/engines/dot/dot.ts
@@ -240,8 +240,9 @@ export class DotEngine {
     let vizSvg = Viz(
       fs.readFileSync(this.paths.dot).toString(), {
         format: 'svg',
-        engine: 'dot'
-      }, { totalMemory: 32 * 1024 * 1024 });
+        engine: 'dot',
+        totalMemory: 64 * 1024 * 1024
+      });
 
     return new Promise((resolve, reject) => {
         fs.outputFile(


### PR DESCRIPTION
I confirmed this change resolves the TOTAL_MEMORY errors experienced in Compodoc while generating the main graph for large projects. The viz.js dependency is otherwise hard-coded with a 16MB TOTAL_MEMORY limit.